### PR TITLE
Display maximum statue effects (#1136)

### DIFF
--- a/build_info.cpp
+++ b/build_info.cpp
@@ -91,7 +91,7 @@ const vector<BuildInfo>& BuildInfo::get() {
       BuildInfo({FurnitureType::PIGSTY, {ResourceId::WOOD, 5}}, "Pigsty",
           {{RequirementId::TECHNOLOGY, TechId::PIGSTY}},
           "Increases minion population limit by up to " +
-          toString(ModelBuilder::getPigstyPopulationIncrease()) + ".", 0, "Living"),
+          toString(ModelBuilder::getPigstyPopulationIncrease() * ModelBuilder::getMaxUsefulPigsty()) + ".", 0, "Living"),
       BuildInfo({FurnitureType::TRAINING_WOOD, {ResourceId::WOOD, 12}}, "Wooden dummy", {},
           "Train your minions here. Adds up to " +
           toString(*CollectiveConfig::getTrainingMaxLevel(ExperienceType::MELEE, FurnitureType::TRAINING_WOOD)) + " melee levels.",
@@ -154,10 +154,14 @@ const vector<BuildInfo>& BuildInfo::get() {
         "Opens a connection if another portal is present.", 0, "Installations"),
       BuildInfo({FurnitureType::MINION_STATUE, {ResourceId::GOLD, 50}}, "Golden Statue", {},
         "Increases minion population limit by " +
-              toString(ModelBuilder::getStatuePopulationIncrease()) + ".", 0, "Installations"),
+              toString(ModelBuilder::getStatuePopulationIncrease()) + ". (Up to " +
+              toString(ModelBuilder::getStatuePopulationIncrease() * 
+              ModelBuilder::getMaxUsefulGoldStatues()) + ")", 0, "Installations"),
       BuildInfo({FurnitureType::STONE_MINION_STATUE, {ResourceId::STONE, 250}}, "Stone Statue", {},
         "Increases minion population limit by " +
-              toString(ModelBuilder::getStatuePopulationIncrease()) + ".", 0, "Installations"),
+              toString(ModelBuilder::getStatuePopulationIncrease()) + ". (Up to " +
+              toString(ModelBuilder::getStatuePopulationIncrease() * 
+              ModelBuilder::getMaxUsefulStoneStatues()) + ")", 0, "Installations"),
       BuildInfo({FurnitureType::WHIPPING_POST, {ResourceId::WOOD, 20}}, "Whipping post", {},
           "A place to whip your minions if they need a morale boost.", 0, "Installations"),
       BuildInfo({FurnitureType::GALLOWS, {ResourceId::WOOD, 20}}, "Gallows", {},

--- a/model_builder.cpp
+++ b/model_builder.cpp
@@ -44,16 +44,28 @@ ModelBuilder::ModelBuilder(ProgressMeter* m, RandomGen& r, Options* o, SokobanIn
 ModelBuilder::~ModelBuilder() {
 }
 
-int ModelBuilder::getPigstyPopulationIncrease() {
-  return 4;
+double ModelBuilder::getPigstyPopulationIncrease() {
+  return 0.25;
 }
 
-int ModelBuilder::getStatuePopulationIncrease() {
+double ModelBuilder::getStatuePopulationIncrease() {
   return 1;
 }
 
-int ModelBuilder::getThronePopulationIncrease() {
+double ModelBuilder::getThronePopulationIncrease() {
   return 10;
+}
+
+int ModelBuilder::getMaxUsefulStoneStatues() {
+  return 4;
+}
+
+int ModelBuilder::getMaxUsefulGoldStatues() {
+  return 200;
+}
+
+int ModelBuilder::getMaxUsefulPigsty() {
+  return 16;
 }
 
 static CollectiveConfig getKeeperConfig(RandomGen& random, bool fastImmigration, bool regenerateMana, AvatarInfo::ImpVariant impVariant) {
@@ -210,16 +222,16 @@ static CollectiveConfig getKeeperConfig(RandomGen& random, bool fastImmigration,
       {
       CONSTRUCT(PopulationIncrease,
         c.type = FurnitureType::PIGSTY;
-        c.increasePerSquare = 0.25;
-        c.maxIncrease = ModelBuilder::getPigstyPopulationIncrease();),
+        c.increasePerSquare = ModelBuilder::getPigstyPopulationIncrease();
+        c.maxIncrease = c.increasePerSquare * ModelBuilder::getMaxUsefulPigsty();),
       CONSTRUCT(PopulationIncrease,
         c.type = FurnitureType::MINION_STATUE;
         c.increasePerSquare = ModelBuilder::getStatuePopulationIncrease();
-        c.maxIncrease = 200;),
+        c.maxIncrease = c.increasePerSquare * ModelBuilder::getMaxUsefulGoldStatues();),
       CONSTRUCT(PopulationIncrease,
         c.type = FurnitureType::STONE_MINION_STATUE;
         c.increasePerSquare = ModelBuilder::getStatuePopulationIncrease();
-        c.maxIncrease = c.increasePerSquare * 4;),
+        c.maxIncrease = c.increasePerSquare * ModelBuilder::getMaxUsefulStoneStatues();),
       CONSTRUCT(PopulationIncrease,
         c.type = FurnitureType::THRONE;
         c.increasePerSquare = ModelBuilder::getThronePopulationIncrease();

--- a/model_builder.h
+++ b/model_builder.h
@@ -33,9 +33,12 @@ class ModelBuilder {
 
   WCollective spawnKeeper(WModel, AvatarInfo, bool regenerateMana, vector<string> introText);
 
-  static int getPigstyPopulationIncrease();
-  static int getStatuePopulationIncrease();
-  static int getThronePopulationIncrease();
+  static double getPigstyPopulationIncrease();
+  static double getStatuePopulationIncrease();
+  static double getThronePopulationIncrease();
+  static int getMaxUsefulPigsty();
+  static int getMaxUsefulStoneStatues();
+  static int getMaxUsefulGoldStatues();
 
   ~ModelBuilder();
 


### PR DESCRIPTION
* Stone statues can add up to 4 population. Display this information.

* Use constants to centralize max pop increases for statues and pigsty.